### PR TITLE
PHP 5.2 backport

### DIFF
--- a/LeLogger.php
+++ b/LeLogger.php
@@ -73,7 +73,7 @@ class LeLogger
 	// Destroy singleton instance, used in PHPUnit tests
 	public static function tearDown()
 	{	
-		static::$m_instance = NULL;
+		self::$m_instance = NULL;
 	}
 
 	private function __construct($token, $persistent, $use_ssl, $severity)


### PR DESCRIPTION
I don't see any reasons to use LSB here; looks like
the only thing that prevents from using PHP 5.2
