### PR TITLE
Ignoring error message from pfsockopen & fsockopen

### DIFF
--- a/LeLogger.php
+++ b/LeLogger.php
@@ -154,12 +154,12 @@ class LeLogger
 
 	private function my_pfsockopen($port, $address)
 	{
-         return pfsockopen($address, $port, $this->errno, $this->errstr, $this->connectionTimeout);
+         return @pfsockopen($address, $port, $this->errno, $this->errstr, $this->connectionTimeout);
 	}
 
 	private function my_fsockopen($port, $address)
 	{
-		return fsockopen($address, $port, $this->errno, $this->errstr, $this->connectionTimeout);
+		return @fsockopen($address, $port, $this->errno, $this->errstr, $this->connectionTimeout);
 	}
 
 	public function Debug($line)


### PR DESCRIPTION
Ignoring these error messages since they break users application, if the function can't connect to a socket it will return null and be picked up by the is_resource statement.
