### PR TITLE
Expose as composer package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/vendor/
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,22 @@
+{
+    "name": "logentries/logentries",
+    "description": "Logging library for use with Logentries",
+    "autoload": {
+        "classmap": [
+            "./"
+        ]
+    },
+    "license": "MIT",
+    "require-dev": {
+        "phpunit/phpunit": "3.7.*"
+    },
+    "authors": [
+        {
+            "name": "Mark Lacomber",
+            "email": "marklacomber@gmail.com"
+        }
+    ],
+    "require": {
+
+    }
+}

--- a/unit_tests/LeLoggerTests.php
+++ b/unit_tests/LeLoggerTests.php
@@ -1,7 +1,5 @@
 <?php
 
-	require_once('../LeLogger.php');
-
 	class LeLoggerTest extends PHPUnit_Framework_TestCase
 	{
 		/**


### PR DESCRIPTION
This PR should fix issue #6.
Now it's possible to publish this package to [packagist](https://packagist.org/).

I've added this [MIT license](http://opensource.org/licenses/MIT). Please tell me If it's not ok, so I can change it.
Since the current version is 1.6, I suggest you create a tag in your repository.
